### PR TITLE
New file versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,29 @@ sudo apt-get install device-tree-compiler
 
 ## Extract the Foundation model
 
-This needs an account on the ARM site to download. The r9p6 release is known to work.
+This needs an account on the ARM site to download. The r11p0 release is known to work.
 
 ```
-tar xvzf FM000-KT-00035-r9p6-41rel0.tgz
+tar xvzf FM000-KT-00035-r11p0-34rel0.tgz
 ```
 
 ## Download and extract UEFI
 
 ```
-wget http://snapshots.linaro.org/member-builds/armlt-platforms-release/22/fvp-uefi.zip
+wget http://snapshots.linaro.org/member-builds/armlt-platforms-release/$RELEASE/fvp-uefi.zip
 unzip fvp-uefi.zip
 ```
+
+and replace $RELEASE is the latest uefi release. FreeBSD was tested with version 51.
 
 # Download and extract the FreeBSD disk image
 
 ```
-wget http://ftp.freebsd.org/pub/FreeBSD/snapshots/VM-IMAGES/11.0-CURRENT/aarch64/Latest/FreeBSD-11.0-CURRENT-arm64-aarch64.raw.xz
-xz -d FreeBSD-11.0-CURRENT-arm64-aarch64.raw.xz
+wget http://ftp.freebsd.org/pub/FreeBSD/snapshots/VM-IMAGES/$VERSION-CURRENT/aarch64/Latest/FreeBSD-$VERSION-CURRENT-arm64-aarch64.raw.xz
+xz -d FreeBSD-$VERSION-CURRENT-arm64-aarch64.raw.xz
 ```
+
+and replace $VERSION with the latest FreeBSD version. Version 12.0 has been tested and is known to work.
 
 ## Build the device tree blob
 
@@ -37,11 +41,15 @@ xz -d FreeBSD-11.0-CURRENT-arm64-aarch64.raw.xz
 ./fvp-freebsd/build.sh
 ```
 
+The script builds the device tree blob with the GICv3 controller.
+
+**NOTE**: If you want to use a different device tree make sure the device tree blob is located in the same directory as run.sh and has the name `fvp-foundation-gicv3-psci.dtb` in order for the UEFI to automatically detect and load.
+
 # Running FreeBSD
 
 To run FreeBSD there is a script. It will pick up the Model and UEFI if they are in the default location.
 
 ```
-DISK=FreeBSD-11.0-CURRENT-arm64-aarch64.raw ./fvp-freebsd/run.sh
+DISK=FreeBSD-12.0-CURRENT-arm64-aarch64.raw ./fvp-freebsd/run.sh
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,8 @@ ROOT=`dirname $0`
 
 CPPARGS="-P -x assembler-with-cpp"
 CPPARGS="${CPPARGS} -I ${ROOT}/dts"
-#CPPARGS="${CPPARGS} -include ${ROOT}/dts/foundation-v8-gicv3.dts /dev/null"
-CPPARGS="${CPPARGS} -include ${ROOT}/dts/foundation-v8-gicv2.dts /dev/null"
+CPPARGS="${CPPARGS} -include ${ROOT}/dts/foundation-v8-gicv3.dts /dev/null"
+#CPPARGS="${CPPARGS} -include ${ROOT}/dts/foundation-v8-gicv2.dts /dev/null"
 
 cpp ${CPPARGS} | dtc -O dtb -o fvp-foundation-gicv3-psci.dtb -
 

--- a/dts/foundation-v8-gicv2.dts
+++ b/dts/foundation-v8-gicv2.dts
@@ -1,7 +1,7 @@
 /*
  * ARM Ltd.
  *
- * ARMv8 Foundation model DTS (GICv3 configuration)
+ * ARMv8 Foundation model DTS (GICv2 configuration)
  */
 
 #include "foundation-v8.dtsi"


### PR DESCRIPTION
Hello, I'm working on porting bhyve to ARMv8 and I've started by booting FreeBSD on the Foundation Platform using your repository.

This pull request updates the file versions used.

This is the boot log with the patch and using run.sh (that means gicv3 and the ARMv8.3 architecture on by default): [bootlog_14072017.txt](https://github.com/zxombie/fvp-freebsd/files/1147856/bootlog_14072017.txt).


